### PR TITLE
expand capabilities and fix status filtering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,10 +132,10 @@ GET /api/jobs/search
 ```
 
 **Query Parameters:**
-- `capability` - Filter by capability (DATA, WORKDAY, ENGINEERING)
+- `capability` - Filter by capability (DATA, WORKDAY, ENGINEERING, PRODUCT, DESIGN, PLATFORM, QUALITY, ARCHITECTURE, BUSINESS_ANALYSIS, SECURITY)
 - `band` - Filter by band (Junior, Mid, Senior, Principal)
 - `location` - Filter by location (partial match)
-- `status` - Filter by status (open, closed, draft)
+- `status` - Filter by status (open, closed)
 - `search` - Text search across job title, description, and responsibilities
 - `page` - Page number for pagination (default: 1)
 - `limit` - Items per page (1-100, default: 10)

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -316,7 +316,7 @@ describe("Job Application Backend API", () => {
         expect(mockJson).toHaveBeenCalledWith({
           success: true,
           message:
-            "Jobs retrieved successfully with filters (capability: Data, band: Junior)",
+            "Jobs retrieved successfully with filters (capability: Data & Analytics, band: Junior)",
           data: [sampleJobs[1]], // Only the Data Junior job
           count: 1,
           filters: { capability: Capability.DATA, band: Band.JUNIOR },
@@ -450,7 +450,6 @@ describe("Job Application Backend API", () => {
 
       expect(Object.values(JobStatus)).toContain(JobStatus.OPEN);
       expect(Object.values(JobStatus)).toContain(JobStatus.CLOSED);
-      expect(Object.values(JobStatus)).toContain(JobStatus.DRAFT);
     });
   });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,10 +28,11 @@ app.get("/", (_req: Request, res: Response) => {
       endpoint: "/api/jobs/search",
       description: "Server-side filtering with query parameters",
       queryParameters: {
-        capability: "Filter by capability (DATA, WORKDAY, ENGINEERING)",
+        capability:
+          "Filter by capability (DATA, WORKDAY, ENGINEERING, PRODUCT, DESIGN, PLATFORM, QUALITY, ARCHITECTURE, BUSINESS_ANALYSIS, SECURITY)",
         band: "Filter by band (Junior, Mid, Senior, Principal)",
         location: "Filter by location (partial match)",
-        status: "Filter by status (open, closed, draft)",
+        status: "Filter by status (open, closed)",
         search:
           "Text search across job title, description, and responsibilities",
         page: "Page number for pagination (default: 1)",

--- a/src/controllers/JobController.test.ts
+++ b/src/controllers/JobController.test.ts
@@ -260,7 +260,7 @@ describe("JobController", () => {
 
     it("should throw BusinessError when validation fails", async () => {
       const validationError = new Error(
-        "Invalid status. Must be one of: open, closed, draft"
+        "Invalid status. Must be one of: open, closed"
       );
       mockJobValidator.createValidatedJob.mockImplementation(() => {
         throw validationError;

--- a/src/db/seeds/jobRolesSeeds.ts
+++ b/src/db/seeds/jobRolesSeeds.ts
@@ -12,7 +12,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Engineering",
     band: "Senior",
     closingDate: "2025-11-15",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 3,
   },
   {
@@ -26,7 +26,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Product",
     band: "Mid",
     closingDate: "2025-10-30",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 2,
   },
   {
@@ -40,7 +40,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Data & Analytics",
     band: "Mid",
     closingDate: "2025-12-01",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 1,
   },
   {
@@ -54,7 +54,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Design",
     band: "Junior",
     closingDate: "2025-11-20",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 2,
   },
   {
@@ -68,7 +68,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Platform",
     band: "Senior",
     closingDate: "2025-10-25",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 1,
   },
   {
@@ -82,7 +82,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Engineering",
     band: "Mid",
     closingDate: "2025-11-10",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 4,
   },
   {
@@ -96,7 +96,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Quality",
     band: "Junior",
     closingDate: "2025-11-05",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 2,
   },
   {
@@ -110,7 +110,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Architecture",
     band: "Principal",
     closingDate: "2025-12-15",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 1,
   },
   {
@@ -124,7 +124,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Business Analysis",
     band: "Mid",
     closingDate: "2025-10-28",
-    status: "Closed",
+    status: "closed",
     numberOfOpenPositions: 0,
   },
   {
@@ -138,7 +138,7 @@ export const jobRolesSeeds: (typeof jobsTable.$inferInsert)[] = [
     capability: "Security",
     band: "Senior",
     closingDate: "2025-11-30",
-    status: "Open",
+    status: "open",
     numberOfOpenPositions: 2,
   },
 ];

--- a/src/models/JobModel.ts
+++ b/src/models/JobModel.ts
@@ -7,15 +7,21 @@ export enum Band {
 }
 
 export enum Capability {
-  DATA = "Data",
+  DATA = "Data & Analytics",
   WORKDAY = "Workday",
   ENGINEERING = "Engineering",
+  PRODUCT = "Product",
+  DESIGN = "Design",
+  PLATFORM = "Platform",
+  QUALITY = "Quality",
+  ARCHITECTURE = "Architecture",
+  BUSINESS_ANALYSIS = "Business Analysis",
+  SECURITY = "Security",
 }
 
 export enum JobStatus {
   OPEN = "open",
   CLOSED = "closed",
-  DRAFT = "draft",
 }
 
 // Job model representing a job posting with all required fields

--- a/src/repositories/JobRepository.test.ts
+++ b/src/repositories/JobRepository.test.ts
@@ -71,7 +71,7 @@ describe("JobRepository - Database Tests", () => {
             closingDate:
               originalJob.closingDate?.toISOString() ??
               new Date().toISOString(),
-            status: originalJob.status ?? JobStatus.DRAFT,
+            status: originalJob.status ?? JobStatus.OPEN,
             numberOfOpenPositions: originalJob.numberOfOpenPositions ?? 0,
           })
           .where(eq(jobsTable.id, Number.parseInt(originalJob.id ?? "0", 10)));
@@ -332,7 +332,7 @@ describe("JobRepository - Database Tests", () => {
         capability: Capability.ENGINEERING,
         band: Band.JUNIOR,
         closingDate: new Date("2025-12-31"),
-        status: JobStatus.DRAFT,
+        status: JobStatus.OPEN,
         numberOfOpenPositions: 1,
       };
 
@@ -355,7 +355,7 @@ describe("JobRepository - Database Tests", () => {
         capability: Capability.DATA,
         band: Band.JUNIOR,
         closingDate: new Date("2025-12-31"),
-        status: JobStatus.DRAFT,
+        status: JobStatus.OPEN,
         numberOfOpenPositions: 1,
       };
 
@@ -408,7 +408,7 @@ describe("JobRepository - Database Tests", () => {
         capability: Capability.ENGINEERING,
         band: Band.JUNIOR,
         closingDate: new Date(),
-        status: JobStatus.DRAFT,
+        status: JobStatus.OPEN,
         numberOfOpenPositions: 1,
       };
 

--- a/src/repositories/JobRepository.ts
+++ b/src/repositories/JobRepository.ts
@@ -58,7 +58,7 @@ class DatabaseJobStore {
       capability: job.capability ?? "",
       band: job.band ?? "",
       closingDate: job.closingDate?.toISOString() ?? new Date().toISOString(),
-      status: job.status ?? JobStatus.DRAFT,
+      status: job.status ?? JobStatus.OPEN,
       numberOfOpenPositions: job.numberOfOpenPositions ?? 0,
     };
   }

--- a/src/routes/CreateJobRoutes.ts
+++ b/src/routes/CreateJobRoutes.ts
@@ -6,9 +6,14 @@ export const createJobRoutes = (jobController: JobController) => {
   const router = Router();
 
   // Job routes - all wrapped with asyncHandler for error handling
+  // Note: /jobs/search MUST come before /jobs/:id to avoid "search" being treated as an ID
   router.get(
     "/jobs",
     asyncHandler(jobController.getAllJobs.bind(jobController))
+  );
+  router.get(
+    "/jobs/search",
+    asyncHandler(jobController.getFilteredJobs.bind(jobController))
   );
   router.get(
     "/jobs/:id",
@@ -21,10 +26,6 @@ export const createJobRoutes = (jobController: JobController) => {
   router.put(
     "/jobs/:id",
     asyncHandler(jobController.editJob.bind(jobController))
-  );
-  router.get(
-    "/jobs/search",
-    asyncHandler(jobController.getFilteredJobs.bind(jobController))
   );
   router.delete(
     "/jobs/:id",

--- a/src/utils/QueryParameterParser.ts
+++ b/src/utils/QueryParameterParser.ts
@@ -10,9 +10,18 @@ import {
 
 /**
  * Parse capability enum from string
+ * Matches either the enum key (e.g., "DATA") or value (e.g., "Data & Analytics")
  */
 function parseCapability(value: string): Capability | null {
   const upperValue = value.toUpperCase();
+  
+  // Try to match by enum key (e.g., DATA, WORKDAY, ENGINEERING)
+  const keyMatch = Object.entries(Capability).find(
+    ([key]) => key === upperValue
+  );
+  if (keyMatch) return keyMatch[1] as Capability;
+  
+  // Try to match by enum value (case-insensitive)
   return (
     Object.values(Capability).find((cap) => cap.toUpperCase() === upperValue) ||
     null

--- a/src/validators/JobValidator.test.ts
+++ b/src/validators/JobValidator.test.ts
@@ -76,12 +76,14 @@ describe("JobValidator", () => {
       expect(() =>
         jobValidator.validateCapability("InvalidCapability")
       ).toThrow(
-        "Invalid capability. Must be one of: Data, Workday, Engineering"
+        "Invalid capability. Must be one of: Data & Analytics, Workday, Engineering, Product, Design, Platform, Quality, Architecture, Business Analysis, Security"
       );
     });
 
     it("should handle all valid capability values", () => {
-      expect(jobValidator.validateCapability("Data")).toBe(Capability.DATA);
+      expect(jobValidator.validateCapability("Data & Analytics")).toBe(
+        Capability.DATA
+      );
       expect(jobValidator.validateCapability("Workday")).toBe(
         Capability.WORKDAY
       );
@@ -122,7 +124,7 @@ describe("JobValidator", () => {
       };
 
       expect(() => jobValidator.validateBandAndCapability(job)).toThrow(
-        "Invalid capability. Must be one of: Data, Workday, Engineering"
+        "Invalid capability. Must be one of: Data & Analytics, Workday, Engineering, Product, Design, Platform, Quality, Architecture, Business Analysis, Security"
       );
     });
   });
@@ -177,16 +179,12 @@ describe("JobValidator", () => {
       it("should handle all valid status values", () => {
         const openData = { ...validJobData, status: "open" };
         const closedData = { ...validJobData, status: "closed" };
-        const draftData = { ...validJobData, status: "draft" };
 
         expect(jobValidator.createValidatedJob(openData).status).toBe(
           JobStatus.OPEN
         );
         expect(jobValidator.createValidatedJob(closedData).status).toBe(
           JobStatus.CLOSED
-        );
-        expect(jobValidator.createValidatedJob(draftData).status).toBe(
-          JobStatus.DRAFT
         );
       });
     });
@@ -303,14 +301,14 @@ describe("JobValidator", () => {
           capability: "InvalidCapability",
         };
         expect(() => jobValidator.createValidatedJob(invalidData)).toThrow(
-          "Invalid capability. Must be one of: Data, Workday, Engineering"
+          "Invalid capability. Must be one of: Data & Analytics, Workday, Engineering, Product, Design, Platform, Quality, Architecture, Business Analysis, Security"
         );
       });
 
       it("should throw error for invalid status", () => {
         const invalidData = { ...validJobData, status: "invalid" };
         expect(() => jobValidator.createValidatedJob(invalidData)).toThrow(
-          "Invalid status. Must be one of: open, closed, draft"
+          "Invalid status. Must be one of: open, closed"
         );
       });
     });


### PR DESCRIPTION
## Related Ticket
https://planner.cloud.microsoft/webui/v1/plan/hje9cdYoUUmS19kW8S3Jj5YABmbQ/view/board/task/Tjd4lRRJJ0iqhEhgBlksppYAFF8F?tid=7ed9bdc7-964d-4dc0-9084-812b90e05c6d

## Description
- Expand Capability enum from 3 to 10 options (add Product, Design, Platform, Quality, Architecture, Business Analysis, Security)
- Fix JobStatus enum to use lowercase values (open/closed) instead of capitalized
- Update seed data to match lowercase status values
- Fix route ordering: /jobs/search now comes before /jobs/:id to prevent parameter conflicts
- Update QueryParameterParser to support enum key matching (e.g., DATA maps to 'Data & Analytics')
- Update all tests to reflect new capability and status values
- Update API documentation and README with new capability options